### PR TITLE
[build] Add a makefile and packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Main binary, build with `go build`
+# Main binary, built with `go build`
 /haulage
+
+# Packages, built with fpm
+/haulage_*.deb

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Git VCS parameters
+VERSION=$(shell git describe)
+USER_EMAIL=$(shell git config --get user.email)
+
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+BINARY_LOCATION=./haulage
+DESCRIPTION="haulage: a minimalist traffic logging framework"
+
+all: build package
+
+build:
+	$(GOBUILD) -o $(BINARY_LOCATION) -v
+
+package: build
+	$(info $$VERSION is [${VERSION}])
+	$(info $$USER_EMAIL is [${USER_EMAIL}])
+	fpm --input-type dir \
+		--output-type deb \
+		--force \
+		--license MPL-2.0 \
+		--vendor uw-ictd \
+		--maintainer matt9j@cs.washington.edu \
+		--description $(DESCRIPTION) \
+		--url "https://github.com/uw-ictd/haulage" \
+		--deb-compression xz \
+		--deb-systemd ./init/haulage.service \
+		--deb-systemd-restart-after-upgrade \
+		--name haulage \
+		--version $(VERSION) \
+		--depends 'libpcap' \
+		$(BINARY_LOCATION)
+
+clean:
+	rm $(BINARY_LOCATION)
+	rm haulage_*\.deb
+


### PR DESCRIPTION
This commit adds a makefile to automate building the haulage binary in
a repeatable way and then generating a debian package from the
binary. This implementation currently does not support cross
compilation.

testing = make build, make clean, make package, make all, make clean