### PR TITLE
Devel dns

### DIFF
--- a/haualge.sql
+++ b/haualge.sql
@@ -1,0 +1,43 @@
+DROP TABLE IF EXISTS `dnsResponses`;
+DROP TABLE IF EXISTS `answers`;
+DROP TABLE IF EXISTS `flowlogs`;
+DROP TABLE IF EXISTS `hosts`;
+
+CREATE TABLE `answers` (
+  `host` varbinary(255) NOT NULL,
+  `ip_addresses` varbinary(512) NOT NULL,
+  `ttls` varbinary(255) NOT NULL,
+  idx bigint UNSIGNED AUTO_INCREMENT,
+  UNIQUE KEY (host, ip_addresses, ttls),
+  PRIMARY KEY (idx)
+) ENGINE=InnoDB;
+
+CREATE TABLE dnsResponses (
+  time timestamp NOT NULL,
+  src_ip binary(16) NOT NULL,
+  dest_ip binary(16) NOT NULL,
+  opcode int UNSIGNED NOT NULL,
+  resultcode int UNSIGNED NOT NULL,
+  answer bigint UNSIGNED NOT NULL,
+  FOREIGN KEY (answer) REFERENCES answers(idx)
+) ENGINE=InnoDB;
+
+CREATE TABLE `hosts` (
+  `hostID` bigint(20) NOT NULL AUTO_INCREMENT,
+  `hostname` varbinary(128) NOT NULL,
+  `ipAddress` varbinary(16) NOT NULL,
+  PRIMARY KEY (`hostID`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `flowlogs` (
+  `intervalStart` timestamp NOT NULL,
+  `intervalStop` timestamp NOT NULL,
+  `addressA` varbinary(16) NOT NULL,
+  `addressB` varbinary(16) NOT NULL,
+  `hostA` bigint NOT NULL,
+  `hostB` bigint NOT NULL,
+  `bytesAtoB` bigint NOT NULL,
+  `bytesBtoA` bigint NOT NULL,
+  FOREIGN KEY (hostA) REFERENCES hosts(hostID),
+  FOREIGN KEY (hostB) REFERENCES hosts(hostID)
+) ENGINE=InnoDB;

--- a/internal/classify/dns.go
+++ b/internal/classify/dns.go
@@ -1,0 +1,69 @@
+package classify
+
+import (
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	log "github.com/sirupsen/logrus"
+
+	"fmt"
+	"net"
+	"time"
+)
+
+type DnsMsg struct {
+	Timestamp       time.Time
+	SourceIP        net.IP
+	DestinationIP   net.IP
+	DnsQuery        string
+	DnsOpCode       uint16
+	DnsResponseCode uint16
+	NumberOfAnswers uint16
+	DnsAnswerTTL    []uint32
+	DnsAnswer       []net.IP
+}
+
+// Attempts to parse a dns payload from the provided packet.
+//
+// Nominally returns a parsed DnsMsg struct with the DNS information.
+// If no DNS information is detected in the packet returns a NoDNSError.
+// Otherwise returns generic error codes for parsing failure.
+func ParseDns(pkt gopacket.Packet, msg *DnsMsg) error {
+	dnsLayer := pkt.Layer(layers.LayerTypeDNS)
+
+	if dnsLayer == nil {
+		return fmt.Errorf("No DNS payload detected")
+	}
+
+	var dns layers.DNS
+	var df gopacket.DecodeFeedback
+	err := dns.DecodeFromBytes(dnsLayer.LayerContents(), df)
+	if err != nil {
+		return err
+	}
+
+	if len(dns.Questions) != 1 {
+		log.Warningf("DNS layer is malformed with %d questions", len(dns.Questions))
+		return fmt.Errorf("DNS layer is malformed")
+	}
+
+	dnsQuestion := dns.Questions[0]
+
+	// Add a document to the index
+	msg.Timestamp = time.Now()
+	msg.SourceIP = net.ParseIP(pkt.NetworkLayer().NetworkFlow().Src().String())
+	msg.DestinationIP = net.ParseIP(pkt.NetworkLayer().NetworkFlow().Src().String())
+	msg.DnsQuery = string(dnsQuestion.Name)
+	msg.DnsOpCode = uint16(dns.OpCode)
+	msg.DnsResponseCode = uint16(dns.ResponseCode)
+	msg.NumberOfAnswers = dns.ANCount
+
+	if dns.ANCount > 0 {
+		for _, dnsAnswer := range dns.Answers {
+			if dnsAnswer.IP.String() != "<nil>" {
+				msg.DnsAnswerTTL = append(msg.DnsAnswerTTL, dnsAnswer.TTL)
+				msg.DnsAnswer = append(msg.DnsAnswer, dnsAnswer.IP)
+			}
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -77,10 +77,15 @@ func classifyPacket(packet gopacket.Packet, wg *sync.WaitGroup) {
 
 	// Check for errors
 	if err := packet.ErrorLayer(); err != nil {
-		log.Error("Error decoding some part of the packet:", err)
+		log.Debug("Error decoding some part of the packet:", err)
 	}
 
 	sendToFlowHandler(flowEvent{packet.NetworkLayer().NetworkFlow(), len(packet.NetworkLayer().LayerPayload())}, wg)
+	var msg classify.DnsMsg
+	if err := classify.ParseDns(packet, &msg); err == nil {
+		// Errors are expected, since most packets are not valid DNS.
+		LogDNS(&msg, wg)
+	}
 }
 
 func sendToFlowHandler(event flowEvent, wg *sync.WaitGroup) {


### PR DESCRIPTION
This branch adds DNS logging to haulage to aid host based flow classification and get a better idea of which domains are contacted by users in the network. The logs are stored as entries in the persistent local SQL db. More efficient formats might be possible, particularly with compression between records since many DNS requests will return redundant information to users for common popular domains.