### PR TITLE
Add logging of data used by services of interest

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 flowLogInterval: "20m"
 userLogInterval: "1m"
-interface: "wlp1s0"
+interface: "eth0"
 
 custom:
   reenablePollInterval: "5s"

--- a/custom.go
+++ b/custom.go
@@ -10,9 +10,12 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/google/gopacket"
 	log "github.com/sirupsen/logrus"
-	"github.com/uw-ictd/haulage/internal/classify"
-	"github.com/uw-ictd/haulage/internal/iptables"
-	"github.com/uw-ictd/haulage/internal/storage"
+	//"github.com/uw-ictd/haulage/internal/classify"
+	//"github.com/uw-ictd/haulage/internal/iptables"
+	//"github.com/uw-ictd/haulage/internal/storage"
+	"haulage/internal/classify"
+	"haulage/internal/iptables"
+	"haulage/internal/storage"
 )
 
 type Context struct {

--- a/haulage.sql
+++ b/haulage.sql
@@ -39,9 +39,24 @@ CREATE TABLE `flowlogs` (
 
 CREATE TABLE `servicelogs` (
   `service` varchar(255) CHARACTER SET ascii NOT NULL,
+  `aliases` varchar(255) CHARACTER SET ascii NOT NULL,
   `totalbytes` bigint NOT NULL,
   `numusers` smallint UNSIGNED NOT NULL,
   idx bigint UNSIGNED AUTO_INCREMENT,
   UNIQUE KEY (service),
   PRIMARY KEY (idx)
 ) ENGINE=InnoDB;
+
+INSERT INTO `servicelogs`(`service`, `aliases`, `totalbytes`, `numusers`) VALUES 
+('total', '', 0, 0), 
+('whatsapp', 'whatsapp', 0, 0), 
+('google', 'google, gmail', 0, 0), 
+('facebook', 'facebook, fbcdn, fbsbx', 0, 0), 
+('twitter', 'twitter, twimg', 0, 0), 
+('youtube', 'youtube, ytimg', 0, 0), 
+('instagram', 'instagram', 0, 0), 
+('wikipedia', 'wikipedia', 0, 0), 
+('akamai', 'akamai', 0, 0), 
+('amazonaws', 'amazonaws', 0, 0), 
+('cloudfront', 'cloudfront', 0, 0), 
+('cloudflare', 'cloudflare', 0, 0);

--- a/haulage.sql
+++ b/haulage.sql
@@ -1,6 +1,7 @@
 DROP TABLE IF EXISTS `dnsResponses`;
 DROP TABLE IF EXISTS `answers`;
 DROP TABLE IF EXISTS `flowlogs`;
+DROP TABLE IF EXISTS `servicelogs`;
 
 CREATE TABLE `answers` (
   `host` varchar(255) CHARACTER SET ascii NOT NULL,
@@ -34,4 +35,13 @@ CREATE TABLE `flowlogs` (
   `portB` smallint UNSIGNED NOT NULL,
   `bytesAtoB` bigint NOT NULL,
   `bytesBtoA` bigint NOT NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE `servicelogs` (
+  `service` varchar(255) CHARACTER SET ascii NOT NULL,
+  `totalbytes` bigint NOT NULL,
+  `numusers` smallint UNSIGNED NOT NULL,
+  idx bigint UNSIGNED AUTO_INCREMENT,
+  UNIQUE KEY (service),
+  PRIMARY KEY (idx)
 ) ENGINE=InnoDB;

--- a/internal/storage/dbface.go
+++ b/internal/storage/dbface.go
@@ -7,7 +7,8 @@ import (
 	"github.com/google/gopacket"
 	"github.com/shopspring/decimal"
 	log "github.com/sirupsen/logrus"
-	"github.com/uw-ictd/haulage/internal/classify"
+	//"github.com/uw-ictd/haulage/internal/classify"
+	"haulage/internal/classify"
 	"net"
 	"time"
 )

--- a/main.go
+++ b/main.go
@@ -12,7 +12,8 @@ import (
 	"github.com/google/gopacket/pcap"
 	"github.com/jessevdk/go-flags"
 	log "github.com/sirupsen/logrus"
-	"github.com/uw-ictd/haulage/internal/classify"
+	//"github.com/uw-ictd/haulage/internal/classify"
+	"haulage/internal/classify"
 	"gopkg.in/yaml.v2"
 )
 
@@ -287,6 +288,7 @@ func parseConfig(path string) {
 
 func main() {
 	log.Info("Starting haulage")
+	log.Info("Testing build")
 
 	// Setup flags
 	_, err := flags.Parse(&opts)
@@ -307,9 +309,9 @@ func main() {
 	log.WithField("Parameters", config).Info("Parsed parameters")
 
 	// Open device
-	handle, err = pcap.OpenLive(config.Interface, snapshotLen, promiscuous, snapshotTimeout)
+	//handle, err = pcap.OpenLive(config.Interface, snapshotLen, promiscuous, snapshotTimeout)
 	// Open file
-	// handle, err = pcap.OpenOffline("testdata/small.pcap")
+	handle, err = pcap.OpenOffline("testdata/large.pcap")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -318,7 +320,8 @@ func main() {
 	log.Info("Initializing context")
 	OnStart(&ctx, params)
 	log.Info("Context initialization complete")
-	start_radius_server(ctx.db)
+	//start_radius_server(ctx.db)
+	log.Info("Does this run after radius server")
 	defer Cleanup(&ctx)
 	log.Info("Context initialization complete")
 
@@ -335,6 +338,7 @@ func main() {
 		log.Fatal("Terminating Uncleanly! Connections may be orphaned.")
 	}()
 
+	log.Info("Does this run after signal notify")
 	// Skip directly to decoding IPv4 on the tunneled packets.
 	// TODO(matt9j) Make this smarter to use ip4 or ip6 based on the tunnel address and type?
 	layers.LinkTypeMetadata[12] = layers.EnumMetadata{

--- a/read_db.py
+++ b/read_db.py
@@ -1,28 +1,106 @@
 # File for accessing MySQL data
 
 import MySQLdb
+import csv
+import time
 
-def mysql_connect(hostname, username, password, dbname):
+
+HOSTNAME = "localhost"
+USERNAME = "colte_db"
+PASSWORD = "colte_db"
+DBNAME = "colte_db"
+
+SERVICES = ['whatsapp', 'facebook', 'youtube']
+
+TP_OUTFILE = 'tp_data.tsv'
+USERS_OUTFILE = 'users_data.tsv'
+
+
+def servicelogs_init(services):
     try:
-        connection = MySQLdb.connect(hostname, username, password, dbname)
-
+        connection = MySQLdb.connect(HOSTNAME, USERNAME, PASSWORD, DBNAME)
     except:
-        print("Error: can't connect to db")
+        print("Error: can't connect to db to init services")
         return 0
 
-    print("Connected to db")
-
     cursor = connection.cursor()
-    cursor.execute("SELECT * FROM servicelogs")
-    for row in cursor.fetchall():
-        print row
-    #cursor.execute("INSERT INTO servicelogs(service, totalbytes, numusers) VALUES ('Whatsapp', 1, 1)")
+    for s in services:
+        try:
+            cursor.execute("INSERT INTO servicelogs(service, totalbytes, numusers) VALUES (%s, 0, 0)", (s,))
+        except:
+            print("Error: db INSERT failed on %s".format(s))
+
+    # DEBUG
     cursor.execute("SELECT * FROM servicelogs")
     for row in cursor.fetchall():
         print row
 
+    # close connection
     cursor.close()
     connection.commit()
     connection.close()
 
-mysql_connect("localhost", "colte_db", "colte_db", "colte_db")
+
+def servicelogs_get(services):
+    new_nums = []
+
+    try:
+        connection = MySQLdb.connect(HOSTNAME, USERNAME, PASSWORD, DBNAME)
+    except:
+        print("Error: can't connect to db to update")
+        return 0
+
+    cursor = connection.cursor()
+    for s in services:
+        cursor.execute("SELECT * from servicelogs WHERE service = %s", (s,))
+        # there should only be one row otherwise something is wrong
+        tup = cursor.fetchone()
+        print tup
+        new_nums.append(tup)
+
+    # DEBUG
+    #cursor.execute("SELECT * FROM servicelogs")
+    #for row in cursor.fetchall():
+    #    print row
+
+    # close connection
+    cursor.close()
+    connection.commit()
+    connection.close()
+
+    return new_nums
+
+
+def process_data(data):
+    throughputs = []
+    users = []
+    for service in data:
+        throughputs.append(service[1])
+        users.append(service[2])
+    return throughputs, users 
+
+
+def write_to_tsv(fn, data):
+    with open(fn, 'a') as f:
+        writer = csv.writer(f, delimiter='\t')
+        writer.writerow(data)
+
+
+# main
+# TODO need to figure out how to initialize all this 
+
+def main():
+    # init functions
+    #servicelogs_init(SERVICES)
+    #write_to_tsv(TP_OUTFILE, SERVICES)
+    #write_to_tsv(USERS_OUTFILE, SERVICES)
+
+    new_data = servicelogs_get(SERVICES)
+    tps, users = process_data(new_data)
+
+    write_to_tsv(TP_OUTFILE, tps)
+    write_to_tsv(USERS_OUTFILE, users)
+    
+
+if __name__ == "__main__":
+    main()

--- a/read_db.py
+++ b/read_db.py
@@ -1,0 +1,28 @@
+# File for accessing MySQL data
+
+import MySQLdb
+
+def mysql_connect(hostname, username, password, dbname):
+    try:
+        connection = MySQLdb.connect(hostname, username, password, dbname)
+
+    except:
+        print("Error: can't connect to db")
+        return 0
+
+    print("Connected to db")
+
+    cursor = connection.cursor()
+    cursor.execute("SELECT * FROM servicelogs")
+    for row in cursor.fetchall():
+        print row
+    #cursor.execute("INSERT INTO servicelogs(service, totalbytes, numusers) VALUES ('Whatsapp', 1, 1)")
+    cursor.execute("SELECT * FROM servicelogs")
+    for row in cursor.fetchall():
+        print row
+
+    cursor.close()
+    connection.commit()
+    connection.close()
+
+mysql_connect("localhost", "colte_db", "colte_db", "colte_db")


### PR DESCRIPTION
These changes add the functionality of logging data used by services of interest, modifying the following files: haulage.sql, main.go, custom.go, internal/storage/dbface.go, and adding the file read_db.py. 
The script read_db.py pulls the most recent usage data from the new db table servicelogs and writes it to a tsv file; it may be run at some time interval.
The services of interest are currently hardcoded in the initialization of the servicelogs table, done in haulage.sql.
The following new code was added:
In custom.go: FindService, LogServiceUsage
In dbface.go: storage.LogServiceDB, QueryServiceIPs
In main.go: inside flowHandler, code to log total usage amount
In haulage.sql: code to create servicelogs table and initialize services of interest