### PR TITLE
Devel nat uplink limiting

### DIFF
--- a/haulage/src/enforcer.rs
+++ b/haulage/src/enforcer.rs
@@ -203,8 +203,13 @@ async fn enforce_via_iptables(
             .unwrap();
 
             let mark_string = format!("0x{:X}{}", id_offset + 2, &sub_limit_state.qdisc_handle);
-            if !mark_rule_present(&sub_limit_state.ip.ip(), &mark_string).await.unwrap() {
-                set_mark_rule(&sub_limit_state.ip.ip(), &mark_string, &log).await.unwrap();
+            if !mark_rule_present(&sub_limit_state.ip.ip(), &mark_string)
+                .await
+                .unwrap()
+            {
+                set_mark_rule(&sub_limit_state.ip.ip(), &mark_string, &log)
+                    .await
+                    .unwrap();
             }
         }
 
@@ -300,11 +305,23 @@ async fn forwarding_reject_rule_present(addr: &std::net::IpAddr) -> Result<bool,
 
     Ok(output.status.success())
 }
-async fn mark_rule_present(addr: &std::net::IpAddr, mark_string: &str) -> Result<bool, std::io::Error> {
+async fn mark_rule_present(
+    addr: &std::net::IpAddr,
+    mark_string: &str,
+) -> Result<bool, std::io::Error> {
     // IPTables holds state outside the lifetime of this program. The `-C`
     // option will return success if the rule is present, and 1 if it is not.
     let output = tokio::process::Command::new("iptables")
-        .args(&["-C", "FORWARD", "-s", &addr.to_string(), "-j", "MARK", "--set-mark", mark_string])
+        .args(&[
+            "-C",
+            "FORWARD",
+            "-s",
+            &addr.to_string(),
+            "-j",
+            "MARK",
+            "--set-mark",
+            mark_string,
+        ])
         .output()
         .await?;
 
@@ -494,7 +511,16 @@ async fn set_mark_rule(
     }
 
     let command_status = tokio::process::Command::new("iptables")
-        .args(&["-I", "FORWARD", "-s", &ip.to_string(), "-j", "MARK", "--set-mark", mark_string])
+        .args(&[
+            "-I",
+            "FORWARD",
+            "-s",
+            &ip.to_string(),
+            "-j",
+            "MARK",
+            "--set-mark",
+            mark_string,
+        ])
         .status()
         .await?;
 

--- a/haulage/src/enforcer.rs
+++ b/haulage/src/enforcer.rs
@@ -952,7 +952,7 @@ async fn query_subscriber_access_policy(
                 SELECT "internal_uid" AS "subscriber_id", "access_policies"."id" AS "policy_id", "local_ul_policy_kind", "local_ul_policy_parameters", "local_dl_policy_kind", "local_dl_policy_parameters", "backhaul_ul_policy_kind", "backhaul_ul_policy_parameters", "backhaul_dl_policy_kind", "backhaul_dl_policy_parameters"
                 FROM subscribers
                 INNER JOIN access_policies ON subscribers.positive_balance_policy = access_policies.id
-                WHERE (subscriber_id = $1)
+                WHERE (internal_uid = $1)
             "#
         }
         SubscriberCondition::NoBalance => {
@@ -960,7 +960,7 @@ async fn query_subscriber_access_policy(
                 SELECT "internal_uid" AS "subscriber_id", "access_policies"."id" AS "policy_id", "local_ul_policy_kind", "local_ul_policy_parameters", "local_dl_policy_kind", "local_dl_policy_parameters", "backhaul_ul_policy_kind", "backhaul_ul_policy_parameters", "backhaul_dl_policy_kind", "backhaul_dl_policy_parameters"
                 FROM subscribers
                 INNER JOIN access_policies ON subscribers.zero_balance_policy = access_policies.id
-                WHERE (subscriber_id = $1)
+                WHERE (internal_uid = $1)
             "#
         }
     };


### PR DESCRIPTION
This pull request attempts to address https://github.com/uw-ictd/haulage/issues/35 by attributing packets to each user with a firewall mark rather than a TC filter. Using a mark allows flexibility in where the mark is applied, allowing the packet to be rate limited as it leaves the host node but attributed to a particular user earlier in the forwarding pipeline before NAT.